### PR TITLE
Contracting neighbouring dimensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorCore"
 uuid = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -5,4 +5,41 @@
 [![Codecov](https://codecov.io/gh/JuliaMath/TensorCore.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaMath/TensorCore.jl)
 
 This package is intended as a lightweight foundation for tensor operations across the Julia ecosystem.
-Currently it exports two core operations, `hadamard` and `tensor`, and corresponding unicode operators `⊙` and `⊗`, respectively.
+Currently it exports three operations:
+* `hadamard` elementwise multiplication, with unicode operator `⊙`,
+* `tensor` product preserves all dimensions, operator `⊗`, and
+* `boxdot` contracts neighbouring dimensions, named after the unicode `⊡`.
+
+```julia
+julia> using TensorCore
+
+julia> A = [1 2 3; 4 5 6]; B = [7 8 9; 0 10 20];
+
+julia> A ⊙ B  # hadamard(A, B)
+2×3 Matrix{Int64}:
+ 7  16   27
+ 0  50  120
+
+julia> V = [1, 10];
+
+julia> C = A ⊗ V  # tensor(A, V)
+2×3×2 Array{Int64, 3}:
+[:, :, 1] =
+ 1  2  3
+ 4  5  6
+
+[:, :, 2] =
+ 10  20  30
+ 40  50  60
+
+julia> summary(A ⊗ B)
+"2×3×2×3 Array{Int64, 4}"
+
+julia> C ⊡ V  # boxdot(C, V)
+2×3 Matrix{Int64}:
+ 101  202  303
+ 404  505  606
+
+julia> summary(C ⊡ rand(2,5,7))
+"2×3×5×7 Array{Float64, 4}"
+ ```

--- a/src/TensorCore.jl
+++ b/src/TensorCore.jl
@@ -277,8 +277,8 @@ end
     TensorCore._adjoint(A)
 
 This extends `adjoint` to understand higher-dimensional arrays, always reversing the
-order of dimensions. On Julia 1.5 and later, the symbol `'` can be overloaded by
-`var"'" = TensorCore._adjoint`.
+order of dimensions. On Julia 1.5 and later, the symbol `'` can be overloaded as
+`Base.var"'"`, as shown below.
 
 Then `(x ⊡ y)' == y' ⊡ x'` holds for `x` and `y` arrays of any dimension.
 ```
@@ -287,9 +287,9 @@ julia> T3 = rand(3,4,5); v = rand(5);
 julia> size(T3 ⊡ v')
 (3, 4)
 
-julia> @pirate adjoint
+julia> Base.var"'"(a::AbstractArray) = TensorCore._adjoint(a)
 
-julia> v ⊡ T3' == (T3 ⊡ v')'
+julia> v ⊡ T3' ≈ (T3 ⊡ v')'
 true
 ```
 """
@@ -298,7 +298,7 @@ _adjoint(x::AbstractVecOrMat) = adjoint(x)
 _adjoint(x::AbstractArray{T,N}) where {T,N} = conj(PermutedDimsArray(x, ntuple(i -> N-i+1, N)))
 
 _transpose(x) = transpose(x)
-_transpose(x::AbstractVecOrMat) = adjoint(x)
+_transpose(x::AbstractVecOrMat) = transpose(x)
 _transpose(x::AbstractArray{T,N}) where {T,N} = PermutedDimsArray(x, ntuple(i -> N-i+1, N))
 
 end

--- a/src/TensorCore.jl
+++ b/src/TensorCore.jl
@@ -211,23 +211,13 @@ boxdot(a::Number, B::AbstractArray) = a*B
 boxdot(a::Number, b::Number) = a*b
 
 """
-    boxdot!(Y, A, B)
+    boxdot!(Y, A, B, α=1, β=0)
 
-In-place version of `boxdot`, i.e. `Y .= A ⊡ B`.
+In-place version of `boxdot`, i.e. `Y .= (A ⊡ B) .* β .+ Y .* α`.
 """
-function boxdot!(Y::AbstractArray, A::AbstractArray, B::AbstractArray)
-    (Y isa AdjOrTransAbsVec || A isa AdjOrTransAbsVec || B isa AdjOrTransAbsVec) &&
-        error("boxdot! can't handle row vectors yet")
-    sz = prod(size(A)[1:end-1]), prod(size(B)[2:end])
-    mul!(reshape(Y, sz), _squash_left(A), _squash_right(B))
-    Y
-end
-
-function boxdot!(Y::AbstractArray, A::AbstractArray, B::AbstractArray, α::Number, β::Number=zero(eltype(Y)))
-    (Y isa AdjOrTransAbsVec || A isa AdjOrTransAbsVec || B isa AdjOrTransAbsVec) &&
-        error("boxdot! can't handle row vectors yet")
-    sz = prod(size(A)[1:end-1]), prod(size(B)[2:end])
-    mul!(reshape(Y, sz), _squash_left(A), _squash_right(B), α, β)
+function boxdot!(Y::AbstractArray, A::AbstractArray, B::AbstractArray, α::Number=true, β::Number=false)
+    szY = prod(size(A)[1:end-1]), prod(size(B)[2:end])
+    mul!(reshape(Y, szY), _squash_left(A), _squash_right(B), α, β)
     Y
 end
 
@@ -259,8 +249,9 @@ boxdot(A::TransposeAbsVec, B::AbstractArray) = vec(A) ⊡ B
 boxdot(A::AbstractArray, B::AdjointAbsVec) = A ⊡ vec(B)
 boxdot(A::AbstractArray, B::TransposeAbsVec) = A ⊡ vec(B)
 
-# Each of these can have a matching method for boxdot!,
-# although Y may need some thought, perhaps pass a function in?
+# For boxdot!, only where mul! behaves differently:
+boxdot!(Y::AbstractArray, A::AbstractArray, B::AdjOrTransAbsVec,
+    α::Number=true, β::Number=false) = boxdot!(Y, A, vec(B))
 
 """
     TensorCore._adjoint(A)

--- a/src/TensorCore.jl
+++ b/src/TensorCore.jl
@@ -297,10 +297,12 @@ true
 """
 _adjoint(x) = adjoint(x)
 _adjoint(x::AbstractVecOrMat) = adjoint(x)
-_adjoint(x::AbstractArray{T,N}) where {T,N} = conj(PermutedDimsArray(x, ntuple(i -> N-i+1, N)))
+_adjoint(x::AbstractArray{T,N}) where {T<:Number,N} = conj(PermutedDimsArray(x, ntuple(i -> N-i+1, N)))
+_adjoint(x::AbstractArray{T,N}) where {T,N} = adjoint.(PermutedDimsArray(x, ntuple(i -> N-i+1, N)))
 
 _transpose(x) = transpose(x)
 _transpose(x::AbstractVecOrMat) = transpose(x)
-_transpose(x::AbstractArray{T,N}) where {T,N} = PermutedDimsArray(x, ntuple(i -> N-i+1, N))
+_transpose(x::AbstractArray{T,N}) where {T<:Number,N} = PermutedDimsArray(x, ntuple(i -> N-i+1, N))
+_transpose(x::AbstractArray{T,N}) where {T,N} = transpose.(PermutedDimsArray(x, ntuple(i -> N-i+1, N)))
 
 end

--- a/src/TensorCore.jl
+++ b/src/TensorCore.jl
@@ -278,8 +278,8 @@ end
     TensorCore._adjoint(A)
 
 This extends `adjoint` to understand higher-dimensional arrays, always reversing the
-order of dimensions. On Julia 1.5 and later, the symbol `'` can be overloaded as
-`Base.var"'"`, as shown below.
+order of dimensions. On Julia 1.5 and later, the symbol `'` can be overloaded locally
+as `var"'"`, as shown below.
 
 Then `(x ⊡ y)' == y' ⊡ x'` holds for `x` and `y` arrays of any dimension.
 
@@ -289,9 +289,9 @@ julia> T3 = rand(3,4,5); v = rand(5);
 julia> size(T3 ⊡ v')
 (3, 4)
 
-julia> Base.var"'"(a::AbstractArray) = TensorCore._adjoint(a)
-
-julia> v ⊡ T3' ≈ (T3 ⊡ v')'
+julia> let var"'" = TensorCore._adjoint
+         v ⊡ T3' ≈ (T3 ⊡ v')'
+       end
 true
 ```
 """

--- a/src/TensorCore.jl
+++ b/src/TensorCore.jl
@@ -234,22 +234,22 @@ end
 using LinearAlgebra: AdjointAbsVec, TransposeAbsVec, AdjOrTransAbsVec
 
 # Adjont and Transpose, vectors or almost (returning a scalar)
-boxdot(A::AdjointAbsVec, B::AbstractVector) = vec(A) ⊡ B # maybe not optimal
-boxdot(A::TransposeAbsVec, B::AbstractVector) = vec(A) ⊡ B
+boxdot(A::AdjointAbsVec, B::AbstractVector) = A * B
+boxdot(A::TransposeAbsVec, B::AbstractVector) = A * B
 
 boxdot(A::AbstractVector, B::AdjointAbsVec) = A ⊡ vec(B)
 boxdot(A::AbstractVector, B::TransposeAbsVec) = A ⊡ vec(B)
 
-boxdot(A::AdjointAbsVec, B::AdjointAbsVec) = adjoint(adjoint(A) ⊡ adjoint(B))
+boxdot(A::AdjointAbsVec, B::AdjointAbsVec) = adjoint(adjoint(B) ⊡ adjoint(A))
 boxdot(A::AdjointAbsVec, B::TransposeAbsVec) = vec(A) ⊡ vec(B)
 boxdot(A::TransposeAbsVec, B::AdjointAbsVec) = vec(A) ⊡ vec(B)
-boxdot(A::TransposeAbsVec, B::TransposeAbsVec) = vec(A) ⊡ vec(B)
+boxdot(A::TransposeAbsVec, B::TransposeAbsVec) = transpose(transpose(B) ⊡ transpose(A))
 
 # ... with a matrix (returning another such)
 boxdot(A::AdjointAbsVec, B::AbstractMatrix) = A * B
 boxdot(A::TransposeAbsVec, B::AbstractMatrix) = A * B
 
-boxdot(A::AbstractMatrix, B::AdjointAbsVec) = (B' ⊡ A')' # unhappy that this re-orders *
+boxdot(A::AbstractMatrix, B::AdjointAbsVec) = (B' ⊡ A')'
 boxdot(A::AbstractMatrix, B::TransposeAbsVec) = transpose(transpose(B) ⊡ transpose(A))
 
 # ... and with higher-dim (returning a plain array)
@@ -261,8 +261,6 @@ boxdot(A::AbstractArray, B::TransposeAbsVec) = A ⊡ vec(B)
 
 # Each of these can have a matching method for boxdot!,
 # although Y may need some thought, perhaps pass a function in?
-
-# For complex v, vec(v') is going to cause generic_mul!, can you avoid that?
 
 """
     TensorCore._adjoint(A)

--- a/src/TensorCore.jl
+++ b/src/TensorCore.jl
@@ -132,7 +132,8 @@ export boxdot, ⊡, boxdot!
 Generalised matrix multiplication: Contracts the last dimension of `A` with
 the first dimension of `B`, for any `ndims(A)` & `ndims(B)`.
 If both are vectors, then it returns a scalar `== sum(A .* B)`.
-```
+
+```jldoctest; setup=:(using TensorCore)
 julia> A = rand(3,4,5); B = rand(5,6,7);
 
 julia> size(A ⊡ B)
@@ -141,14 +142,15 @@ julia> size(A ⊡ B)
 julia> typeof(rand(5) ⊡ rand(5))
 Float64
 
-julia> B ⊡ A
-ERROR: DimensionMismatch("neighbouring axes of `A` and `B` must match, got Base.OneTo(6) and Base.OneTo(3)")
+julia> try B ⊡ A catch err println(err) end
+DimensionMismatch("neighbouring axes of `A` and `B` must match, got Base.OneTo(7) and Base.OneTo(3)")
 ```
 This is the same behaviour as Mathematica's function `Dot[A, B]`.
 
 When interacting with `Adjoint` vectors, this always obeys `(x ⊡ y)' == y' ⊡ x'`,
 and hence may sometimes return another `Adjoint` vector. (And similarly for `Transpose`.)
-```
+
+```jldoctest; setup=:(using TensorCore)
 julia> M = rand(5,5); v = rand(5);
 
 julia> typeof(v ⊡ M')
@@ -280,7 +282,8 @@ order of dimensions. On Julia 1.5 and later, the symbol `'` can be overloaded as
 `Base.var"'"`, as shown below.
 
 Then `(x ⊡ y)' == y' ⊡ x'` holds for `x` and `y` arrays of any dimension.
-```
+
+```jldoctest; setup=:(using TensorCore)
 julia> T3 = rand(3,4,5); v = rand(5);
 
 julia> size(T3 ⊡ v')

--- a/src/TensorCore.jl
+++ b/src/TensorCore.jl
@@ -202,7 +202,7 @@ function boxdot(A::AbstractVector, B::AbstractVector)
     if eltype(A) <: Number
         return transpose(A)*B
     else
-        return sum(a*b for a in A, b in B)
+        return sum(a*b for (a,b) in zip(A,B))
     end
 end
 

--- a/src/TensorCore.jl
+++ b/src/TensorCore.jl
@@ -4,6 +4,8 @@ using LinearAlgebra
 
 export ⊙, hadamard, hadamard!
 export ⊗, tensor, tensor!
+export ⊡, boxdot, boxdot!
+export @pirate
 
 """
     hadamard(a, b)
@@ -122,5 +124,187 @@ function tensor!(dest::AbstractArray, A::AbstractArray, B::AbstractArray)
     end
     return dest
 end
+
+export boxdot, ⊡, boxdot!
+
+"""
+    boxdot(A,B) = A ⊡ B    # \\boxdot
+
+Generalised matrix multiplication: Contracts the last dimension of `A` with
+the first dimension of `B`, for any `ndims(A)` & `ndims(B)`.
+If both are vectors, then it returns a scalar `== sum(A .* B)`.
+```
+julia> A = rand(3,4,5); B = rand(5,6,7);
+
+julia> size(A ⊡ B)
+(3, 4, 6, 7)
+
+julia> typeof(rand(5) ⊡ rand(5))
+Float64
+
+julia> B ⊡ A
+ERROR: DimensionMismatch("neighbouring axes of `A` and `B` must match, got Base.OneTo(6) and Base.OneTo(3)")
+```
+This is the same behaviour as Mathematica's function `Dot[A, B]`.
+
+When interacting with `Adjoint` vectors, this always obeys `(x ⊡ y)' == y' ⊡ x'`,
+and hence may sometimes return another `Adjoint` vector. (And similarly for `Transpose`.)
+```
+julia> M = rand(5,5); v = rand(5);
+
+julia> typeof(v ⊡ M')
+Array{Float64,1}
+
+julia> typeof(M ⊡ v') # adjoint of the previous line
+Adjoint{Float64,Array{Float64,1}}
+
+julia> typeof(v' ⊡ M') # same as *, and equal to adjoint(M ⊡ v)
+Adjoint{Float64,Array{Float64,1}}
+
+julia> typeof(v' ⊡ v)
+Float64
+```
+See also `boxdot!(Y,A,B)`, which is to `⊡` as `mul!` is to `*`.
+"""
+function boxdot(A::AbstractArray, B::AbstractArray)
+    Amat = _squash_left(A)
+    Bmat = _squash_right(B)
+
+    axA, axB = axes(Amat,2), axes(Bmat,1)
+    axA == axB || _throw_dmm(axA, axB)
+
+    return reshape(Amat * Bmat, _boxdot_size(A,B))
+end
+
+const ⊡ = boxdot
+
+@noinline _throw_dmm(axA, axB) = throw(DimensionMismatch("neighbouring axes of `A` and `B` must match, got $axA and $axB"))
+
+_squash_left(A::AbstractArray) = reshape(A, :,size(A,ndims(A)))
+_squash_left(A::AbstractMatrix) = A
+
+_squash_right(B::AbstractArray) = reshape(B, size(B,1),:)
+_squash_right(B::AbstractVecOrMat) = B
+
+_boxdot_size(A::AbstractArray{T,N}, B::AbstractArray{S,M}) where {T,N,S,M} =
+    ntuple(i -> i<N ? size(A, i) : size(B, i-N+2), Val(N+M-2))
+
+# These can skip final reshape:
+boxdot(A::AbstractMatrix, B::AbstractVecOrMat) = A*B
+
+# These produce scalar output:
+function boxdot(A::AbstractVector, B::AbstractVector)
+    axA, axB = axes(A,1), axes(B,1)
+    axA == axB || _throw_dmm(axA, axB)
+    if eltype(A) <: Number
+        return transpose(A)*B
+    else
+        return sum(a*b for a in A, b in B)
+    end
+end
+
+# Multiplication by a scalar:
+boxdot(A::AbstractArray, b::Number) = A*b
+boxdot(a::Number, B::AbstractArray) = a*B
+boxdot(a::Number, b::Number) = a*b
+
+"""
+    boxdot!(Y, A, B)
+
+In-place version of `boxdot`, i.e. `Y .= A ⊡ B`.
+"""
+function boxdot!(Y::AbstractArray, A::AbstractArray, B::AbstractArray)
+    (Y isa AdjOrTransAbsVec || A isa AdjOrTransAbsVec || B isa AdjOrTransAbsVec) &&
+        error("boxdot! can't handle row vectors yet")
+    sz = prod(size(A)[1:end-1]), prod(size(B)[2:end])
+    mul!(reshape(Y, sz), _squash_left(A), _squash_right(B))
+    Y
+end
+
+function boxdot!(Y::AbstractArray, A::AbstractArray, B::AbstractArray, α::Number, β::Number=zero(eltype(Y)))
+    (Y isa AdjOrTransAbsVec || A isa AdjOrTransAbsVec || B isa AdjOrTransAbsVec) &&
+        error("boxdot! can't handle row vectors yet")
+    sz = prod(size(A)[1:end-1]), prod(size(B)[2:end])
+    mul!(reshape(Y, sz), _squash_left(A), _squash_right(B), α, β)
+    Y
+end
+
+using LinearAlgebra: AdjointAbsVec, TransposeAbsVec, AdjOrTransAbsVec
+
+# Adjont and Transpose, vectors or almost (returning a scalar)
+boxdot(A::AdjOrTransAbsVec, B::AbstractVector) = vec(A) ⊡ B # maybe not optimal
+boxdot(A::AbstractVector, B::AdjOrTransAbsVec) = A ⊡ vec(B)
+
+boxdot(A::AdjointAbsVec, B::AdjointAbsVec) = adjoint(adjoint(A) ⊡ adjoint(B))
+boxdot(A::AdjointAbsVec, B::TransposeAbsVec) = vec(A) ⊡ vec(B)
+boxdot(A::TransposeAbsVec, B::AdjointAbsVec) = vec(A) ⊡ vec(B)
+boxdot(A::TransposeAbsVec, B::TransposeAbsVec) = vec(A) ⊡ vec(B)
+
+# ... with a matrix (returning another such)
+boxdot(A::AdjOrTransAbsVec, B::AbstractMatrix) = A * B
+
+boxdot(A::AbstractMatrix, B::AdjointAbsVec) = (B' ⊡ A')' # unhappy that this re-orders *
+boxdot(A::AbstractMatrix, B::TransposeAbsVec) = transpose(transpose(B) ⊡ transpose(A))
+
+# ... and with higher-dim (returning a plain array)
+boxdot(A::AdjOrTransAbsVec, B::AbstractArray) = vec(A) ⊡ B
+boxdot(A::AdjOrTransAbsVec, B::AbstractVecOrMat) = vec(A) ⊡ B # avoids an ambiguity
+boxdot(A::AbstractArray, B::AdjOrTransAbsVec) = A ⊡ vec(B)
+boxdot(A::AbstractVecOrMat, B::AdjOrTransAbsVec) = A ⊡ vec(B)
+
+# There are still some method ambiguities
+
+# Each of these can have a matching method for boxdot!,
+# although Y may need some thought, perhaps pass a function in?
+
+# For complex v, vec(v') is going to cause generic_mul!, can you avoid that?
+
+"""
+    @pirate adjoint transpose
+
+This adds methods for higher-dimensional arrays, which always reverse the
+order of dimensions, and conjugate in the case of `adjoint`.
+
+Ensures that `(x ⊡ y)' == y' ⊡ x'` holds for `x` and `y` arrays of any dimension.
+```
+julia> T3 = rand(3,4,5); v = rand(5);
+
+julia> size(T3 ⊡ v')
+(3, 4)
+
+julia> @pirate adjoint
+
+julia> v ⊡ T3' == (T3 ⊡ v')'
+true
+```
+On Julia 1.5, it should be possible to override `'` locally
+(instead of committing piracy) by writing `var"'" = TensorCore._adjoint`,
+thanks to this PR: https://github.com/JuliaLang/julia/pull/34634 .
+"""
+macro pirate(exs...)
+    out = quote end
+    for ex in exs
+        if ex == :adjoint
+            for N in 3:16
+                @eval $LinearAlgebra.adjoint(x::AbstractArray{T,$N}) where {T} = $_adjoint(x)
+            end
+        elseif ex == :transpose
+            for N in 3:16
+                @eval $LinearAlgebra.transpose(x::AbstractArray{T,$N}) where {T} = $_transpose(x)
+            end
+        else
+            error("don't understand $ex")
+        end
+    end
+    nothing
+end
+
+_adjoint(x) = adjoint(x)
+_adjoint(x::AbstractVecOrMat) = adjoint(x)
+_adjoint(x::AbstractArray{T,N}) where {T,N} = conj(PermutedDimsArray(x, ntuple(i -> N-i+1, N)))
+
+_transpose(x) = transpose(x)
+_transpose(x::AbstractVecOrMat) = adjoint(x)
+_transpose(x::AbstractArray{T,N}) where {T,N} = PermutedDimsArray(x, ntuple(i -> N-i+1, N))
 
 end

--- a/src/TensorCore.jl
+++ b/src/TensorCore.jl
@@ -5,7 +5,6 @@ using LinearAlgebra
 export ⊙, hadamard, hadamard!
 export ⊗, tensor, tensor!
 export ⊡, boxdot, boxdot!
-export @pirate
 
 """
     hadamard(a, b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,11 +117,18 @@ end
     E3 = cat(A, -B, dims=3)
     F4 = cat(E3, conj(E3 .+ 1), dims=4)
     E3adjoint = conj(permutedims(E3, (3,2,1)))
+    E3lazy = PermutedDimsArray(permutedims(E3, (3,2,1)), (3,2,1))
+    F4lazy = PermutedDimsArray(permutedims(F4, (4,3,2,1)), (4,3,2,1))
+    @test E3lazy == E3
+    @test F4lazy == F4
 
     @test E3 ⊡ A == reshape(reshape(E3, 4,2) * A, 2,2,2)
     @test size(A ⊡ E3) == (2, 2, 2)
     @test size(B ⊡ F4) == (2, 2, 2, 2)
     @test size(E3 ⊡ F4) == (2, 2, 2, 2, 2)
+    @test E3lazy ⊡ A == E3 ⊡ A
+    @test E3lazy ⊡ F4lazy == E3 ⊡ F4
+    @test F4lazy ⊡ E3lazy == F4 ⊡ E3
 
     @test c ⊡ E3 == reshape(transpose(c) * reshape(E3, 2,4), 2,2)
     @test size(F4 ⊡ c) == (2, 2, 2)
@@ -130,6 +137,7 @@ end
     @test c' ⊡ E3 == conj(c) ⊡ E3
     @test c' ⊡ E3 == (E3adjoint ⊡ c)'
     @test transpose(c) ⊡ E3 == c ⊡ E3
+    @test c ⊡ E3lazy == c ⊡ E3
 
     @test E3 ⊡ c' isa Matrix
     @test E3 ⊡ c' == E3 ⊡ conj(c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,9 +174,17 @@ end
     A = [1 2+im; 3 4im]
     E3 = cat(A, -A, dims=3)
     F4 = cat(E3, conj(E3 .+ 1), dims=4)
+    M3 = [rand(ComplexF32, 2,2) for _ in 1:3, _ in 1:4, _ in 1:5];
 
     @test TensorCore._adjoint(E3) == conj(permutedims(E3, (3,2,1)))
     @test TensorCore._transpose(F4) == permutedims(F4, (4,3,2,1))
     @test TensorCore._adjoint(A) == A'
     @test TensorCore._transpose(A) == transpose(A)
+
+    @test TensorCore._adjoint(M3)[5,4,3] == adjoint(M3[3,4,5])
+    @test TensorCore._transpose(M3)[1,2,3] == transpose(M3[3,2,1])
+
+    @test TensorCore._adjoint(E3 ⊗ F4) == TensorCore._adjoint(F4) ⊗ TensorCore._adjoint(E3)
+    @test TensorCore._adjoint(E3 ⊡ F4) == TensorCore._adjoint(F4) ⊡ TensorCore._adjoint(E3)
+    @test TensorCore._adjoint(M3 ⊡ TensorCore._adjoint(M3)) ≈ M3 ⊡ TensorCore._adjoint(M3)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,4 +144,17 @@ end
     @test_throws DimensionMismatch ones(2,3) ⊡ ones(4)'
     @test_throws DimensionMismatch ones(2,3) ⊡ ones(4,5)
 
+    # In-place
+    @test boxdot!(similar(c), A, c) == A * c
+    @test boxdot!(similar(c), A, c, 100) == A * c * 100
+    @test boxdot!(copy(c), B, d, 100, -5) == B * d * 100 .- 5 .* c
+
+    @test boxdot!(similar(c), A, c') == A * conj(c)
+    @test boxdot!(similar(c,1), c, d') == [sum(c .* conj(d))]
+
+    @test boxdot!(similar(c)', c', A) == c' * A
+    @test boxdot!(similar(c,1,2), c', A) == c' * A
+
+    @test boxdot!(similar(c,1), c', d) == [dot(c, d)]
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,8 +146,10 @@ end
 
     # In-place
     @test boxdot!(similar(c), A, c) == A * c
-    @test boxdot!(similar(c), A, c, 100) == A * c * 100
-    @test boxdot!(copy(c), B, d, 100, -5) == B * d * 100 .- 5 .* c
+    if VERSION >= v"1.3"
+        @test boxdot!(similar(c), A, c, 100) == A * c * 100
+        @test boxdot!(copy(c), B, d, 100, -5) == B * d * 100 .- 5 .* c
+    end
 
     @test boxdot!(similar(c), A, c') == A * conj(c)
     @test boxdot!(similar(c,1), c, d') == [sum(c .* conj(d))]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,31 +2,11 @@ using TensorCore
 using LinearAlgebra
 using Test
 
-#=
-@testset "Ambiguities" begin
-    @test isempty(detect_ambiguities(TensorCore, Base, Core, LinearAlgebra))
+if VERSION < v"1.5-"
+    @testset "Ambiguities" begin
+        @test isempty(detect_ambiguities(TensorCore, Base, Core, LinearAlgebra))
+    end
 end
-
-# Ambiguities to solve:
-
-8-element Array{SubString{String},1}:
- "[(boxdot(A::AbstractArray{T,2} where T, B::Union{AbstractArray{T,1}, AbstractArray{T,2}} where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:193, boxdot(A::AbstractArray, B::Union{Adjoint{T,#s664}, Transpose{T,#s664}} where #s664<:(AbstractArray{T,1} where T) where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:252"
-
- "boxdot(A::Union{Adjoint{T,#s664}, Transpose{T,#s664}} where #s664<:(AbstractArray{T,1} where T) where T, B::AbstractArray{T,2} where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:245, boxdot(A::AbstractArray, B::Union{Adjoint{T,#s664}, Transpose{T,#s664}} where #s664<:(AbstractArray{T,1} where T) where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:252"
-
- "boxdot(A::AbstractArray{T,2} where T, B::Adjoint{T,#s664} where #s664<:(AbstractArray{T,1} where T) where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:247, boxdot(A::Union{Adjoint{T,#s664}, Transpose{T,#s664}} where #s664<:(AbstractArray{T,1} where T) where T, B::AbstractArray) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:251"
-
- "boxdot(A::Union{Adjoint{T,#s664}, Transpose{T,#s664}} where #s664<:(AbstractArray{T,1} where T) where T, B::AbstractArray) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:251, boxdot(A::AbstractArray, B::Union{Adjoint{T,#s664}, Transpose{T,#s664}} where #s664<:(AbstractArray{T,1} where T) where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:252"
-
- "boxdot(A::Union{Adjoint{T,#s664}, Transpose{T,#s664}} where #s664<:(AbstractArray{T,1} where T) where T, B::AbstractArray{T,2} where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:245, boxdot(A::AbstractArray{T,2} where T, B::Transpose{T,#s664} where #s664<:(AbstractArray{T,1} where T) where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:248"
-
- "boxdot(A::Union{Adjoint{T,#s664}, Transpose{T,#s664}} where #s664<:(AbstractArray{T,1} where T) where T, B::AbstractArray{T,2} where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:245, boxdot(A::AbstractArray{T,2} where T, B::Adjoint{T,#s664} where #s664<:(AbstractArray{T,1} where T) where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:247"
-
- "boxdot(A::AbstractArray{T,2} where T, B::Transpose{T,#s664} where #s664<:(AbstractArray{T,1} where T) where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:248, boxdot(A::Union{Adjoint{T,#s664}, Transpose{T,#s664}} where #s664<:(AbstractArray{T,1} where T) where T, B::AbstractArray) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:251"
-
- "boxdot(A::AbstractArray{T,2} where T, B::Union{AbstractArray{T,1}, AbstractArray{T,2}} where T) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:193, boxdot(A::Union{Adjoint{T,#s664}, Transpose{T,#s664}} where #s664<:(AbstractArray{T,1} where T) where T, B::AbstractArray) in TensorCore at /Users/me/.julia/dev/TensorCore/src/TensorCore.jl:251)]"
-
-=#
 
 @testset "tensor and hadamard" begin
     for T in (Int, Float32, Float64, BigFloat)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -168,5 +168,15 @@ end
     @test boxdot!(similar(c,1,2), c', A) == c' * A
 
     @test boxdot!(similar(c,1), c', d) == [dot(c, d)]
+end
 
+@testset "_adjoint" begin
+    A = [1 2+im; 3 4im]
+    E3 = cat(A, -A, dims=3)
+    F4 = cat(E3, conj(E3 .+ 1), dims=4)
+
+    @test TensorCore._adjoint(E3) == conj(permutedims(E3, (3,2,1)))
+    @test TensorCore._transpose(F4) == permutedims(F4, (4,3,2,1))
+    @test TensorCore._adjoint(A) == A'
+    @test TensorCore._transpose(A) == transpose(A)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,10 @@ using TensorCore
 using LinearAlgebra
 using Test
 
-if VERSION < v"1.5-"
-    @testset "Ambiguities" begin
+@testset "Ambiguities" begin
+    if VERSION >= v"1.6-"
+        @test isempty(detect_ambiguities(TensorCore))
+    else
         @test isempty(detect_ambiguities(TensorCore, Base, Core, LinearAlgebra))
     end
 end


### PR DESCRIPTION
I wonder whether this package is a natural home for a multiplication operators which allow for higher-dimensional arrays. One such operation is simply to contract the last dimension of `A` with the first dimension of `B`. This contraction isn't especially privileged by some higher mathematical concern, but it is often useful, and unambiguous. This PR provides an implementation. 

I'm not aware of a standard name or symbol for this; it's called `Dot[A, B]` in Mathematica. But on two vectors it is not `LinearAlgebra.dot` since it doesn't conjugate anything. On two matrices it is the same as `*` (and very unlike `dot`). On higher arrays, it’s not the same as `numpy.dot`, which contracts the last dimension with the second-last dimension (but also keeps all others). For now I've written it `⊡` which is typed `\boxdot`, so I adopted that as a name too.

The slightly awkward question is how this should handle adjoint vectors `v'` (and similarly `Transpose`). I think that a nice way to decide this is to demand the following invariance, for any dimension of `x` and `y`:
```julia
(x ⊡ y)' == y' ⊡ x'
```
Then it is clear that `v' ⊡ v'` must be another scalar. And since, for matrix `M`, both `M ⊡ v` and `v ⊡ M` are ordinary vectors, `v' ⊡ M'` must again be an adjoint vector (matching what `*` gives) as must `M ⊡ v'`.

There are more details to fix, but perhaps I open this to see if it's a good idea in general. 